### PR TITLE
⚡️ Add authcore swagger json prefetch header in register

### DIFF
--- a/pages/in/register/index.vue
+++ b/pages/in/register/index.vue
@@ -34,6 +34,7 @@ export default {
       ],
       link: [
         { rel: 'preconnect', href: AUTHCORE_API_HOST, crossorigin: 'true' },
+        { rel: 'prefetch', href: `${AUTHCORE_API_HOST}/api/authapi/authcore.swagger.json?v=0.2` },
         { rel: 'prefetch', href: `${AUTHCORE_API_HOST}/api/auth/widgets/settings` },
       ],
     };


### PR DESCRIPTION
After communication with authcore, they will be patching correct content-type header for the swagger.json, making it prefetch-able