### PR TITLE
🚑 Do not transpile authcore and secretd

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -247,11 +247,6 @@ const nuxtConfig = {
         ],
       ],
     },
-    transpile: [
-      'authcore-js',
-      'secretd-js',
-      'lodash-es',
-    ],
     extend(config, { isClient }) {
       /* eslint-disable no-param-reassign */
       // https://github.com/ethereum/web3.js/issues/1178

--- a/store/modules/actions/authCore.js
+++ b/store/modules/actions/authCore.js
@@ -2,7 +2,7 @@ import { AuthCoreAuthClient } from 'authcore-js';
 import * as types from '@/store/mutation-types';
 import { AUTHCORE_API_HOST } from '@/constant';
 
-const { AuthcoreVaultClient, AuthcoreCosmosProvider } = require('secretd-js');
+import { AuthcoreVaultClient, AuthcoreCosmosProvider } from 'secretd-js';
 
 export async function fetchAuthCoreAccessTokenAndUser({ dispatch }, code) {
   const authClient = await new AuthCoreAuthClient({


### PR DESCRIPTION
This fixs secretd-js cannot import bignumber.js properly due to transpile

Previously I encountered a `unexpected token "export"` error after upgrading authcore, so I added authcore to transpile
It seems that that error is gone now