### PR TITLE
🔥 Remove tx toolbar to fix txdialog throws 500 on click

### DIFF
--- a/components/toolbars/ToolBars.vue
+++ b/components/toolbars/ToolBars.vue
@@ -67,14 +67,6 @@
           :isInTransaction="getIsInTransaction"
         />
 
-        <tx-toolbar
-          v-if="getPendingTx"
-          :txHash="getPendingTx"
-          :txInfo="getPendingTxInfo"
-          :isInTx="getIsInTransaction"
-          @onClose="closeTxToolbar"
-        />
-
         <info-toolbar
           v-if="getInfoMsg"
           :isError="getInfoIsError"
@@ -146,7 +138,6 @@ import TxDialog from '~/components/dialogs/TxDialog';
 
 import InfoToolbar from '~/components/toolbars/InfoToolbar';
 import LoadingToolbar from '~/components/toolbars/LoadingToolbar';
-import TxToolbar from '~/components/toolbars/TxToolbar';
 
 export default {
   name: 'tool-bars',
@@ -163,7 +154,6 @@ export default {
 
     InfoToolbar,
     LoadingToolbar,
-    TxToolbar,
   },
   props: {
     disableError: {
@@ -226,7 +216,6 @@ export default {
   methods: {
     ...mapActions([
       'closeTxDialog',
-      'closeTxToolbar',
       'closeInfoToolbar',
       'openPopupDialog',
       'closePopupDialog',

--- a/store/modules/actions/payment.js
+++ b/store/modules/actions/payment.js
@@ -13,7 +13,6 @@ export async function sendCosmosPayment(
   {
     signer,
     isWait = true,
-    showTxToolBar = false,
     showDialogAction = true,
     ...payload
   },
@@ -46,10 +45,8 @@ export async function sendCosmosPayment(
     }
     commit(types.UI_START_LOADING_TX);
     commit(types.UI_SET_HIDE_TX_DIALOG_ACTION, !showDialogAction);
-    if (showTxToolBar) {
-      commit(types.PAYMENT_SET_PENDING_HASH, txHash);
-      commit(types.PAYMENT_SET_PENDING_TX_INFO, { from, to, value });
-    }
+    commit(types.PAYMENT_SET_PENDING_HASH, txHash);
+    commit(types.PAYMENT_SET_PENDING_TX_INFO, { from, to, value });
     if (isWait) await included();
     commit(types.UI_STOP_LOADING_TX);
     return txHash;


### PR DESCRIPTION
Now the tx dialog returns 500 since pending Tx is not set
We actually didn't set pendingTx due to it triggering tx toolbar, we don't actually use it anyway, so I am removing it in this PR