### PR TITLE
🥅 Guard invalid tags in iscn-ar

### DIFF
--- a/pages/in/widget/iscn-ar/index.vue
+++ b/pages/in/widget/iscn-ar/index.vue
@@ -474,7 +474,6 @@ export default {
     async onReceiveISCNData(data) {
       const {
         fingerprints = [],
-        tags = [],
         url,
         publisher,
         author,
@@ -485,6 +484,7 @@ export default {
         license,
         type,
         name,
+        tags = [],
       } = data;
       type = type || 'article';
       if (publisher) {
@@ -503,6 +503,12 @@ export default {
       if (name) {
         name = name.substring(0, 255);
       }
+      if (!tags) {
+        tags = [];
+      } else if (typeof tags === 'string') {
+        tags = tags.split(',');
+      }
+
       const ISCNData = {
         fingerprints,
         name,


### PR DESCRIPTION
some iscn records somehow has empty string `keywords`, adding a guard in widget before we find out which part is buggy