### PR TITLE
🚸 Use latest iscn id when updating iscn

### DIFF
--- a/util/cosmos/iscn/query.js
+++ b/util/cosmos/iscn/query.js
@@ -19,6 +19,13 @@ export async function getISCNQueryClient() {
   return queryClient;
 }
 
+export function getISCNPrefix(input) {
+  const res = /^(iscn:\/\/likecoin-chain\/[A-Za-z0-9-_]+)(?:\/([0-9]*))?$/.exec(input);
+  if (!res) throw new Error(`Invalid ISCN ID ${input}`);
+  const [, prefix] = res;
+  return prefix;
+}
+
 export async function getISCNTransferInfo(txHash, opt) {
   const apiClient = await getApiClient();
   const { blocking } = opt;

--- a/util/cosmos/iscn/sign.js
+++ b/util/cosmos/iscn/sign.js
@@ -4,6 +4,7 @@ import { ISCNSigningClient } from '@likecoin/iscn-js';
 import bech32 from 'bech32';
 import { ISCN_RPC_URL } from './constant';
 import { EXTERNAL_URL } from '../../../constant';
+import { getISCNPrefix, getISCNInfoById } from './query';
 
 let isConnected;
 let iscnClient;
@@ -204,7 +205,9 @@ export async function signISCNTx(
   const client = await getISCNSigningClient(signer);
   let res;
   if (iscnId) {
-    res = await client.updateISCNRecord(address, iscnId, payload, { memo, broadcast });
+    const iscnPrefix = getISCNPrefix(iscnId);
+    const { latestVersion } = await getISCNInfoById(iscnPrefix);
+    res = await client.updateISCNRecord(address, `${iscnPrefix}/${latestVersion}`, payload, { memo, broadcast });
   } else {
     res = await client.createISCNRecord(address, payload, { memo, broadcast });
   }


### PR DESCRIPTION
To avoid errors like https://www.mintscan.io/likecoin/txs/C681E9B6AA12821BD1EA5E6D8DCC40FFEB85A4859DD5013B361376203E7756C3
In which iscn-ar widget user normally does not care the original version