### PR TITLE
🚑 Fix unable to login with WC for Android

### DIFF
--- a/components/v2/dialogs/AuthDialogV2.vue
+++ b/components/v2/dialogs/AuthDialogV2.vue
@@ -190,7 +190,6 @@
 </template>
 <script>
 import { mapActions, mapGetters } from 'vuex';
-import { isIOS } from '@walletconnect/browser-utils';
 
 import { logTrackerEvent } from '@/util/EventLogger';
 import User from '@/util/User';
@@ -497,7 +496,6 @@ export default {
       try {
         const { platform, payload } = await this.loginByCosmosWallet({
           source,
-          isIOS: isIOS(),
           isRetry,
         });
         // HACK: platform might change according to prefix

--- a/store/modules/actions/user.js
+++ b/store/modules/actions/user.js
@@ -173,7 +173,6 @@ export function resetLoginByCosmosWallet({ commit }) {
 
 export async function loginByCosmosWallet({ commit }, {
   source,
-  isIOS = false,
   isRetry = false,
 } = {}) {
   let walletAddress = '';
@@ -192,15 +191,11 @@ export async function loginByCosmosWallet({ commit }, {
             commit(types.USER_SET_WALLET_CONNECT_CONNECTING, true);
           }
         },
-        isConnectOnly: isIOS,
+        isConnectOnly: true,
         isRetry,
       });
-      if (isIOS) {
-        payload = await WalletConnect.requestForLogin(LOGIN_MESSAGE);
-      } else {
-        walletAddress = await WalletConnect.getWalletAddress();
-        signer = s => WalletConnect.signLogin(s);
-      }
+      payload = await WalletConnect.requestForLogin(LOGIN_MESSAGE);
+      walletAddress = payload.from;
       break;
     }
 


### PR DESCRIPTION
This should temporarily fix the issue by using a single WC request for login same as iOS

The complete fix should be removing the exit app behavior in the Android app

Issue: https://discord.com/channels/763001015712350231/814761730349596712/1050354783833296928